### PR TITLE
Do not use aliases

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ let
 
         buildInputs = [
           self.glib
-          self.gnome3.gtk3
+          self.gtk3
         ];
 
         cargoSha256 = "1cdni03x161hvpzbkqq4g11c86f3scygrpjzbdirvgx3fdh03qv9";

--- a/shell.nix
+++ b/shell.nix
@@ -25,7 +25,7 @@ stdenv.mkDerivation {
     openssl
 
     glib
-    gnome3.gtk3
+    gtk3
   ];
 
   shellHook = ''


### PR DESCRIPTION
To fix evaluation with

```nix
{
  allowAliases = false;
}
```

in `~/.config/nixpkgs/config.nix`.