### PR TITLE
Minor UI cleanup

### DIFF
--- a/glade/ui.glade
+++ b/glade/ui.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAboutDialog" id="aboutDialog">
@@ -7,7 +7,7 @@
     <property name="type_hint">dialog</property>
     <property name="program_name">Glade</property>
     <property name="logo_icon_name">image-missing</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child internal-child="vbox">
@@ -57,7 +57,7 @@
   </object>
   <object class="GtkApplicationWindow" id="appWindow">
     <property name="can_focus">False</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child>
@@ -126,14 +126,17 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_right">1</property>
-            <property name="margin_top">1</property>
-            <property name="margin_bottom">1</property>
+            <property name="margin_left">8</property>
+            <property name="margin_right">8</property>
+            <property name="margin_top">8</property>
+            <property name="margin_bottom">8</property>
+            <property name="spacing">10</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
+                <property name="spacing">8</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
@@ -213,6 +216,7 @@
                     <property name="width_request">500</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="margin_right">8</property>
                     <property name="primary_icon_name">edit-find-symbolic</property>
                     <property name="primary_icon_activatable">False</property>
                     <property name="primary_icon_sensitive">False</property>
@@ -257,6 +261,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="halign">center</property>
+            <property name="margin_bottom">8</property>
             <property name="stack">stack</property>
           </object>
           <packing>
@@ -375,7 +380,7 @@
     <property name="message_type">error</property>
     <property name="buttons">close</property>
     <property name="text" translatable="yes">Error running nix-store</property>
-    <child>
+    <child type="titlebar">
       <placeholder/>
     </child>
     <child internal-child="vbox">


### PR DESCRIPTION
Hello :wave: 

These are rather minor UI improvements that make spacing around UI elements more consistent

**before**

![nix-tree-before](https://user-images.githubusercontent.com/2130305/77361924-6b1b8b80-6d50-11ea-981e-f38090312e45.png)

**after**

![nix-tree-after](https://user-images.githubusercontent.com/2130305/77361942-6fe03f80-6d50-11ea-8218-28e696742672.png)

**Note spaces around items in panel (Sort and search) which make items aligned with rest of the UI.**